### PR TITLE
fix(styles): limpiar estilos globales y deduplicar tabla

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/src/app/features/dashboard/dashboard.component.scss
+++ b/src/app/features/dashboard/dashboard.component.scss
@@ -105,11 +105,11 @@
       height: 24px;
     }
 
-    &--primary { background-color: vars.$np-primary-lighter; mat-icon { color: vars.$np-primary-dark; } }
-    &--success { background-color: #E8F5E9; mat-icon { color: #2E7D32; } }
-    &--warning { background-color: #FFF3E0; mat-icon { color: #E65100; } }
-    &--error   { background-color: #FFEBEE; mat-icon { color: #C62828; } }
-    &--info    { background-color: #E3F2FD; mat-icon { color: #1565C0; } }
+    &--primary { background-color: vars.$np-primary-lighter;  mat-icon { color: vars.$np-primary-dark; } }
+    &--success { background-color: vars.$np-success-bg;       mat-icon { color: vars.$np-success-fg; } }
+    &--warning { background-color: vars.$np-warning-bg;       mat-icon { color: vars.$np-warning-fg; } }
+    &--error   { background-color: vars.$np-error-bg;         mat-icon { color: vars.$np-error-fg; } }
+    &--info    { background-color: vars.$np-info-bg;          mat-icon { color: vars.$np-info-fg; } }
   }
 
   &__trend {
@@ -148,8 +148,8 @@
 }
 
 // Trend colors
-.trend--up    { background-color: #E8F5E9; color: #2E7D32; }
-.trend--down  { background-color: #FFEBEE; color: #C62828; }
+.trend--up      { background-color: vars.$np-success-bg; color: vars.$np-success-fg; }
+.trend--down    { background-color: vars.$np-error-bg;   color: vars.$np-error-fg; }
 .trend--neutral { background-color: vars.$np-background; color: vars.$np-text-secondary; }
 
 // ── Empty state ───────────────────────────────────────────────

--- a/src/app/features/fabricacion/fabricacion.component.html
+++ b/src/app/features/fabricacion/fabricacion.component.html
@@ -25,7 +25,7 @@
           <mat-card-title>Órdenes de Producción</mat-card-title>
           <mat-card-subtitle>{{ ordenes().length }} órdenes activas</mat-card-subtitle>
         </mat-card-header>
-        <mat-card-content class="table-container">
+        <mat-card-content class="np-table-container">
           <table mat-table [dataSource]="ordenes()" class="np-table">
 
             <ng-container matColumnDef="codigo">
@@ -75,7 +75,7 @@
             </ng-container>
 
             <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-            <tr mat-row *matRowDef="let row; columns: displayedColumns;" class="table-row"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns;" class="np-table-row"></tr>
 
             <tr class="mat-row" *matNoDataRow>
               <td class="mat-cell no-data" [attr.colspan]="displayedColumns.length">

--- a/src/app/features/fabricacion/fabricacion.component.scss
+++ b/src/app/features/fabricacion/fabricacion.component.scss
@@ -3,42 +3,13 @@
 
 .fabricacion { height: 100%; }
 
-.table-container {
-  overflow-x: auto;
-  padding: 0 !important;
-}
-
-.np-table {
-  width: 100%;
-
-  th.mat-header-cell {
-    font-weight: 600;
-    color: vars.$np-text-secondary;
-    font-size: 13px;
-    padding: vars.$np-spacing-sm vars.$np-spacing-md;
-    background-color: vars.$np-background;
-  }
-
-  td.mat-cell {
-    padding: vars.$np-spacing-sm vars.$np-spacing-md;
-    font-size: 14px;
-  }
-}
-
-.table-row:hover {
-  background-color: vars.$np-background;
-  cursor: pointer;
-}
+// Table styles are global — see .np-table-container / .np-table / .np-table-row in styles.scss
 
 .progress-cell {
   display: flex;
   align-items: center;
   gap: vars.$np-spacing-sm;
   min-width: 120px;
-}
-
-.progress-bar--success ::ng-deep .mdc-linear-progress__bar-inner {
-  border-color: vars.$np-success;
 }
 
 .progress-label {

--- a/src/app/features/logistica/logistica.component.html
+++ b/src/app/features/logistica/logistica.component.html
@@ -32,7 +32,7 @@
           <mat-card-title>Inventario</mat-card-title>
           <mat-card-subtitle>{{ productos().length }} materiales</mat-card-subtitle>
         </mat-card-header>
-        <mat-card-content class="table-container">
+        <mat-card-content class="np-table-container">
           <table mat-table [dataSource]="productos()" class="np-table">
             <ng-container matColumnDef="codigo">
               <th mat-header-cell *matHeaderCellDef>Código</th>
@@ -63,7 +63,7 @@
               <td mat-cell *matCellDef="let r">{{ r.ubicacion }}</td>
             </ng-container>
             <tr mat-header-row *matHeaderRowDef="colsProductos"></tr>
-            <tr mat-row *matRowDef="let row; columns: colsProductos;" class="table-row"></tr>
+            <tr mat-row *matRowDef="let row; columns: colsProductos;" class="np-table-row"></tr>
           </table>
         </mat-card-content>
       </mat-card>
@@ -74,7 +74,7 @@
           <mat-card-title>Envíos y Recepciones</mat-card-title>
           <mat-card-subtitle>{{ envios().length }} movimientos recientes</mat-card-subtitle>
         </mat-card-header>
-        <mat-card-content class="table-container">
+        <mat-card-content class="np-table-container">
           <table mat-table [dataSource]="envios()" class="np-table">
             <ng-container matColumnDef="referencia">
               <th mat-header-cell *matHeaderCellDef>Referencia</th>
@@ -103,7 +103,7 @@
               </td>
             </ng-container>
             <tr mat-header-row *matHeaderRowDef="colsEnvios"></tr>
-            <tr mat-row *matRowDef="let row; columns: colsEnvios;" class="table-row"></tr>
+            <tr mat-row *matRowDef="let row; columns: colsEnvios;" class="np-table-row"></tr>
           </table>
         </mat-card-content>
       </mat-card>

--- a/src/app/features/logistica/logistica.component.scss
+++ b/src/app/features/logistica/logistica.component.scss
@@ -1,9 +1,20 @@
 @use 'styles/variables' as vars;
+
 .logistica { height: 100%; }
-.table-container { overflow-x: auto; padding: 0 !important; }
-.np-table { width: 100%; }
-.np-table th.mat-header-cell { font-weight: 600; color: vars.$np-text-secondary; font-size: 13px; padding: 8px 16px; background-color: vars.$np-background; }
-.np-table td.mat-cell { padding: 8px 16px; font-size: 14px; }
-.table-row:hover { background-color: vars.$np-background; }
-.alert-banner { display: flex; align-items: center; gap: 8px; background-color: #FFF3E0; border: 1px solid #FFB74D; border-radius: 8px; padding: 12px 16px; margin-bottom: 16px; color: #E65100; font-size: 14px; }
-.alert-banner mat-icon { color: #FF9800; }
+
+// Table styles are global — see .np-table-container / .np-table / .np-table-row in styles.scss
+
+.alert-banner {
+  display: flex;
+  align-items: center;
+  gap: vars.$np-spacing-sm;
+  background-color: vars.$np-warning-bg;
+  border: 1px solid #FFB74D;
+  border-radius: vars.$np-radius-md;
+  padding: vars.$np-spacing-sm vars.$np-spacing-md;
+  margin-bottom: vars.$np-spacing-md;
+  color: vars.$np-warning-fg;
+  font-size: 14px;
+
+  mat-icon { color: vars.$np-warning; }
+}

--- a/src/app/features/mantenimiento/mantenimiento.component.html
+++ b/src/app/features/mantenimiento/mantenimiento.component.html
@@ -13,7 +13,7 @@
           <mat-card-title>Órdenes de Trabajo</mat-card-title>
           <mat-card-subtitle>{{ ordenes().length }} órdenes</mat-card-subtitle>
         </mat-card-header>
-        <mat-card-content class="table-container">
+        <mat-card-content class="np-table-container">
           <table mat-table [dataSource]="ordenes()" class="np-table">
             <ng-container matColumnDef="codigo">
               <th mat-header-cell *matHeaderCellDef>Código</th>
@@ -48,7 +48,7 @@
               <td mat-cell *matCellDef="let r">{{ r.fechaApertura | date:'dd/MM/yyyy' }}</td>
             </ng-container>
             <tr mat-header-row *matHeaderRowDef="colsOrdenes"></tr>
-            <tr mat-row *matRowDef="let row; columns: colsOrdenes;" class="table-row"></tr>
+            <tr mat-row *matRowDef="let row; columns: colsOrdenes;" class="np-table-row"></tr>
           </table>
         </mat-card-content>
       </mat-card>
@@ -59,7 +59,7 @@
           <mat-card-title>Estado de Equipos</mat-card-title>
           <mat-card-subtitle>{{ equipos().length }} equipos registrados</mat-card-subtitle>
         </mat-card-header>
-        <mat-card-content class="table-container">
+        <mat-card-content class="np-table-container">
           <table mat-table [dataSource]="equipos()" class="np-table">
             <ng-container matColumnDef="codigo">
               <th mat-header-cell *matHeaderCellDef>Código</th>
@@ -84,7 +84,7 @@
               <td mat-cell *matCellDef="let r">{{ r.proximoMantenimiento | date:'dd/MM/yyyy' }}</td>
             </ng-container>
             <tr mat-header-row *matHeaderRowDef="colsEquipos"></tr>
-            <tr mat-row *matRowDef="let row; columns: colsEquipos;" class="table-row"></tr>
+            <tr mat-row *matRowDef="let row; columns: colsEquipos;" class="np-table-row"></tr>
           </table>
         </mat-card-content>
       </mat-card>

--- a/src/app/features/mantenimiento/mantenimiento.component.scss
+++ b/src/app/features/mantenimiento/mantenimiento.component.scss
@@ -1,7 +1,2 @@
-@use 'styles/variables' as vars;
+// Table styles are global — see .np-table-container / .np-table / .np-table-row in styles.scss
 .mantenimiento { height: 100%; }
-.table-container { overflow-x: auto; padding: 0 !important; }
-.np-table { width: 100%; }
-.np-table th.mat-header-cell { font-weight: 600; color: vars.$np-text-secondary; font-size: 13px; padding: 8px 16px; background-color: vars.$np-background; }
-.np-table td.mat-cell { padding: 8px 16px; font-size: 14px; }
-.table-row:hover { background-color: vars.$np-background; }

--- a/src/app/features/rrhh/rrhh.component.html
+++ b/src/app/features/rrhh/rrhh.component.html
@@ -13,7 +13,7 @@
           <mat-card-title>Directorio de Personal</mat-card-title>
           <mat-card-subtitle>{{ empleados().length }} empleados ({{ empleados().filter(e => e.activo).length }} activos)</mat-card-subtitle>
         </mat-card-header>
-        <mat-card-content class="table-container">
+        <mat-card-content class="np-table-container">
           <table mat-table [dataSource]="empleados()" class="np-table">
             <ng-container matColumnDef="nombre">
               <th mat-header-cell *matHeaderCellDef>Nombre</th>
@@ -42,7 +42,7 @@
               </td>
             </ng-container>
             <tr mat-header-row *matHeaderRowDef="colsEmpleados"></tr>
-            <tr mat-row *matRowDef="let row; columns: colsEmpleados;" class="table-row"></tr>
+            <tr mat-row *matRowDef="let row; columns: colsEmpleados;" class="np-table-row"></tr>
           </table>
         </mat-card-content>
       </mat-card>
@@ -53,7 +53,7 @@
           <mat-card-title>Solicitudes de Permiso</mat-card-title>
           <mat-card-subtitle>{{ solicitudes().length }} solicitudes</mat-card-subtitle>
         </mat-card-header>
-        <mat-card-content class="table-container">
+        <mat-card-content class="np-table-container">
           <table mat-table [dataSource]="solicitudes()" class="np-table">
             <ng-container matColumnDef="empleado">
               <th mat-header-cell *matHeaderCellDef>Empleado</th>
@@ -78,7 +78,7 @@
               </td>
             </ng-container>
             <tr mat-header-row *matHeaderRowDef="colsSolicitudes"></tr>
-            <tr mat-row *matRowDef="let row; columns: colsSolicitudes;" class="table-row"></tr>
+            <tr mat-row *matRowDef="let row; columns: colsSolicitudes;" class="np-table-row"></tr>
           </table>
         </mat-card-content>
       </mat-card>

--- a/src/app/features/rrhh/rrhh.component.scss
+++ b/src/app/features/rrhh/rrhh.component.scss
@@ -1,7 +1,2 @@
-@use 'styles/variables' as vars;
+// Table styles are global — see .np-table-container / .np-table / .np-table-row in styles.scss
 .rrhh { height: 100%; }
-.table-container { overflow-x: auto; padding: 0 !important; }
-.np-table { width: 100%; }
-.np-table th.mat-header-cell { font-weight: 600; color: vars.$np-text-secondary; font-size: 13px; padding: 8px 16px; background-color: vars.$np-background; }
-.np-table td.mat-cell { padding: 8px 16px; font-size: 14px; }
-.table-row:hover { background-color: vars.$np-background; }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,10 +4,9 @@
 
 @use 'styles/variables' as vars;
 @use 'styles/mixins' as mix;
-
 @use '@angular/material' as mat;
 
-// Angular Material M3 theme - green/white palette
+// ── Angular Material M3 theme ─────────────────────────────────
 html {
   height: 100%;
   @include mat.theme((
@@ -18,23 +17,20 @@ html {
     density: 0,
   ));
 
-  // Override CSS variables for brand identity
-  --mat-sys-primary: #{vars.$np-primary};
-  --mat-toolbar-container-background-color: #{vars.$np-primary};
-  --mat-toolbar-container-text-color: #{vars.$np-text-on-primary};
-  --mat-sidenav-container-background-color: #{vars.$np-white};
-  --mat-sidenav-container-divider-color: #{vars.$np-border};
-  --mat-list-active-indicator-color: #{vars.$np-primary-lighter};
+  // Sidenav token overrides (toolbar overrides live in navbar.component.scss)
+  --mat-sys-primary:                       #{vars.$np-primary};
+  --mat-sidenav-container-background-color:#{vars.$np-white};
+  --mat-sidenav-container-divider-color:   #{vars.$np-border};
+  --mat-list-active-indicator-color:       #{vars.$np-primary-lighter};
 }
 
 body {
   color-scheme: light;
   background-color: vars.$np-background;
   color: vars.$np-text-primary;
-  font: var(--mat-sys-body-medium);
+  font-family: Roboto, 'Helvetica Neue', sans-serif;
   margin: 0;
   height: 100%;
-  font-family: Roboto, 'Helvetica Neue', sans-serif;
 }
 
 // ============================================================
@@ -47,14 +43,11 @@ body {
   margin: 0 auto;
   padding: 0 vars.$np-spacing-md;
 
-  @include mix.respond-to('xs') {
-    padding: 0 vars.$np-spacing-sm;
-  }
+  @include mix.respond-to('xs') { padding: 0 vars.$np-spacing-sm; }
 }
 
 .np-page-content {
   padding: vars.$np-spacing-lg;
-  height: 100%;
   box-sizing: border-box;
 
   @include mix.respond-to('xs') {
@@ -62,13 +55,9 @@ body {
   }
 }
 
-.np-card-grid {
-  @include mix.card-grid();
-}
-
-.np-card-grid--small {
-  @include mix.card-grid(200px);
-}
+.np-card-grid       { @include mix.card-grid(); }
+.np-card-grid--small { @include mix.card-grid(200px); }
+.np-spacer          { flex: 1 1 auto; }
 
 // Color utilities
 .text-primary   { color: vars.$np-primary; }
@@ -78,11 +67,11 @@ body {
 .text-secondary { color: vars.$np-text-secondary; }
 .text-muted     { color: vars.$np-text-disabled; }
 
-.bg-primary         { background-color: vars.$np-primary; color: vars.$np-white; }
-.bg-primary-light   { background-color: vars.$np-primary-lighter; }
-.bg-surface         { background-color: vars.$np-white; }
+.bg-primary       { background-color: vars.$np-primary;         color: vars.$np-white; }
+.bg-primary-light { background-color: vars.$np-primary-lighter; }
+.bg-surface       { background-color: vars.$np-white; }
 
-// Status badges
+// ── Status Badges ─────────────────────────────────────────────
 .np-badge {
   display: inline-flex;
   align-items: center;
@@ -91,44 +80,48 @@ body {
   font-size: 12px;
   font-weight: 500;
 
-  &--success { background-color: #E8F5E9; color: vars.$np-primary-dark; }
-  &--warning { background-color: #FFF3E0; color: #E65100; }
-  &--error   { background-color: #FFEBEE; color: #C62828; }
-  &--info    { background-color: #E3F2FD; color: #1565C0; }
+  &--success { background-color: vars.$np-success-bg; color: vars.$np-success-fg; }
+  &--warning { background-color: vars.$np-warning-bg; color: vars.$np-warning-fg; }
+  &--error   { background-color: vars.$np-error-bg;   color: vars.$np-error-fg; }
+  &--info    { background-color: vars.$np-info-bg;    color: vars.$np-info-fg; }
 }
 
-// Spacer
-.np-spacer { flex: 1 1 auto; }
+// ============================================================
+// Global Table Styles
+// (used by .np-table-container / .np-table / .np-table-row
+//  across fabricacion, logistica, rrhh, mantenimiento)
+// ============================================================
+
+.np-table-container {
+  overflow-x: auto;
+  padding: 0 !important;
+}
+
+.np-table {
+  width: 100%;
+
+  th.mat-header-cell {
+    font-weight: 600;
+    color: vars.$np-text-secondary;
+    font-size: 13px;
+    padding: 8px 16px;
+    background-color: vars.$np-background;
+  }
+
+  td.mat-cell {
+    padding: 8px 16px;
+    font-size: 14px;
+  }
+
+  .np-table-row:hover {
+    background-color: vars.$np-background;
+    cursor: pointer;
+  }
+}
 
 // ============================================================
 // Angular Material Overrides
 // ============================================================
-
-// Toolbar branding
-.mat-toolbar.np-main-toolbar {
-  background-color: vars.$np-primary;
-  color: vars.$np-text-on-primary;
-  box-shadow: vars.$np-shadow-md;
-  position: sticky;
-  top: 0;
-  z-index: 100;
-
-  .mat-icon-button .mat-icon {
-    color: vars.$np-text-on-primary;
-  }
-}
-
-// Sidenav active link
-.mat-nav-list .mat-list-item.active-link {
-  background-color: vars.$np-primary-lighter;
-  border-right: 3px solid vars.$np-primary;
-
-  .mat-icon,
-  .nav-label {
-    color: vars.$np-primary-dark;
-    font-weight: 600;
-  }
-}
 
 // Cards
 .mat-mdc-card.np-card {
@@ -136,31 +129,19 @@ body {
   box-shadow: vars.$np-shadow-sm;
   transition: box-shadow 0.2s ease;
 
-  &:hover {
-    box-shadow: vars.$np-shadow-md;
-  }
-}
-
-// Buttons
-.mat-mdc-raised-button.mat-primary {
-  background-color: vars.$np-primary;
+  &:hover { box-shadow: vars.$np-shadow-md; }
 }
 
 // Forms
-.mat-mdc-form-field {
-  width: 100%;
-}
+.mat-mdc-form-field { width: 100%; }
 
 // ============================================================
-// Scrollbar Styling
+// Scrollbar
 // ============================================================
 
-::-webkit-scrollbar { width: 6px; height: 6px; }
-::-webkit-scrollbar-track { background: vars.$np-surface; }
-::-webkit-scrollbar-thumb {
-  background: vars.$np-primary-light;
-  border-radius: vars.$np-radius-full;
-}
+::-webkit-scrollbar          { width: 6px; height: 6px; }
+::-webkit-scrollbar-track    { background: vars.$np-surface; }
+::-webkit-scrollbar-thumb    { background: vars.$np-primary-light; border-radius: vars.$np-radius-full; }
 ::-webkit-scrollbar-thumb:hover { background: vars.$np-primary; }
 
 // ============================================================
@@ -169,6 +150,6 @@ body {
 @media print {
   .mat-toolbar,
   .mat-sidenav,
-  .np-no-print { display: none !important; }
+  .np-no-print  { display: none !important; }
   .mat-sidenav-content { margin-left: 0 !important; }
 }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -8,13 +8,6 @@
 //   lg  : 1280-1919px(desktops)
 //   xl  : >= 1920px  (large screens / TV)
 
-$breakpoints: (
-  'xs': 600px,
-  'sm': 960px,
-  'md': 1280px,
-  'lg': 1920px,
-);
-
 @mixin respond-to($bp) {
   @if $bp == 'xs' {
     @media (max-width: 599px) { @content; }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -19,11 +19,21 @@ $np-text-secondary: #616161;
 $np-text-disabled:  #9E9E9E;
 $np-text-on-primary:#FFFFFF;
 
-// Semantic
-$np-success:        #4CAF50;
+// Semantic foreground colors
+$np-success:        #43A047;   // distinct from $np-primary
 $np-warning:        #FF9800;
 $np-error:          #F44336;
 $np-info:           #2196F3;
+
+// Semantic background + foreground pairs (used by badges, icon-wraps, trends)
+$np-success-bg:     #E8F5E9;
+$np-success-fg:     #2E7D32;
+$np-warning-bg:     #FFF3E0;
+$np-warning-fg:     #E65100;
+$np-error-bg:       #FFEBEE;
+$np-error-fg:       #C62828;
+$np-info-bg:        #E3F2FD;
+$np-info-fg:        #1565C0;
 
 // Borders & Dividers
 $np-border:         #E0E0E0;


### PR DESCRIPTION
Limpieza completa de CSS global.

- Eliminar estilos de toolbar/active-link duplicados de styles.scss (ahora cada componente gestiona sus propios estilos)
- Tabla global: .np-table-container / .np-table / .np-table-row — elimina copy-paste en 4 features
- Variables semánticas de color en badge/icon-wrap/trend (sin más hex hardcodeados)
- _variables.scss: corregir succes distinto de primary, añadir pares -bg/-fg
- _mixins.scss: eliminar map no utilizado